### PR TITLE
Pass input seed length as argument to the adversary in `PRGSim`

### DIFF
--- a/src/playcrypt/simulator/prg_sim.py
+++ b/src/playcrypt/simulator/prg_sim.py
@@ -16,7 +16,9 @@ class PRGSim(BaseSim):
         :return: 1 for success and 0 for failure.
         """
         self.game.initialize(world)
-        return self.game.finalize(self.adversary(self.game.challenge))
+        return self.game.finalize(self.adversary(
+                                    self.game.challenge, self.game.input_len
+                                ))
 
     def compute_success_ratio(self, world, trials=1000):
         """


### PR DESCRIPTION
Simple one-line fix; makes it possible to pass arbitrary seed length when importing the adversary as a module.